### PR TITLE
Fix par_unsetenv() for VS2015

### DIFF
--- a/myldr/env.c
+++ b/myldr/env.c
@@ -156,6 +156,9 @@ static void
 par_unsetenv(name)
 	const char *name;
 {
+#ifdef WIN32
+	par_setenv(name, "");
+#else
 	extern char **environ;
 	register char **p;
 	int offset;
@@ -164,4 +167,5 @@ par_unsetenv(name)
 		for (p = &environ[offset];; ++p)
 			if (!(*p = *(p + 1)))
 				break;
+#endif
 }


### PR DESCRIPTION
This follows on from the work of commit 5e84ae0506 (RT #120038). Things
seemed to be working fine without this change, but I've since run into
intermittent failures (suggesting memory corruption), which this further
change appears to fix. Again, it's refraining from mucking around directly
with environ, which seems like a Good Thing according to MSDN's _putenv()
documentation. The same manpage also says that _putenv() with an empty
"value" is the correct way to delete an environment variable. I've searched
for any other uses of environ and don't see any more, so hopefully this is
it this time!