### PR TITLE
Fix argument list passed to spawnvpe() call on Windows

### DIFF
--- a/myldr/boot.c
+++ b/myldr/boot.c
@@ -126,6 +126,7 @@ int main ( int argc, char **argv, char **env )
     char *my_prog;
     char buf[20];	/* must be large enough to hold "PAR_ARGV_###" */
 #ifdef WIN32
+    const char **my_argv;
 typedef BOOL (WINAPI *pALLOW)(DWORD);
     HINSTANCE hinstLib;
     pALLOW ProcAdd;
@@ -223,7 +224,13 @@ typedef BOOL (WINAPI *pALLOW)(DWORD);
     }
 
     par_setenv("PAR_SPAWNED", "1");
-    rc = spawnvpe(P_WAIT, my_perl, (char* const*)argv, (char* const*)environ);
+    my_argv = (char**)malloc((argc + 2) * sizeof(char**));
+    my_argv[0] = my_perl;
+    for (i = 0; i < argc; i++) {
+        my_argv[i + 1] = argv[i];
+    }
+    my_argv[argc + 1] = NULL;
+    rc = spawnvp(P_WAIT, my_perl, (const char* const*)my_argv);
 
     par_cleanup(stmpdir);
     exit(rc);


### PR DESCRIPTION
The first argument in the list should be the program name (or path) being
spawned (i.e. the same as the second argument passed to spawnvpe() itself:
my_perl, in this case); the remainder of the argument list are the
arguments for the spawned process. See:
https://msdn.microsoft.com/en-us/library/20y988d2.aspx#Anchor_1
https://msdn.microsoft.com/en-us/library/h565xwht.aspx#Anchor_0

Also, we can simply use spawnvp() rather than spawnvpe() since the
environment being passed to the spawned process is only the current
process's environ, which the spawned process inherits anyway in the case
of spawnvp(). See:
https://msdn.microsoft.com/en-us/library/20y988d2.aspx#Anchor_2

This also avoids referencing environ, which stdlib.h #defines as _environ,
which is not exposed if _CRT_BEST_PRACTICES_USAGE is #defined (in the
Windows 10 SDK used by VS2015).