### PR TITLE
_chase_lib_darwin can return incorrect names for links under OSX.

### DIFF
--- a/lib/PAR/Packer.pm
+++ b/lib/PAR/Packer.pm
@@ -28,6 +28,7 @@ use Config;
 use Archive::Zip ();
 use ExtUtils::MakeMaker (); # just for maybe_command()
 use Cwd ();
+use Cwd 'abs_path';
 use File::Basename ();
 use File::Find ();
 use File::Spec ();
@@ -1457,7 +1458,7 @@ sub _check_par {
 sub _chase_lib {
    my ($self, $file) = @_;
 
-   return $self->_chase_lib_darwin($file) if $^O eq q/darwin/;
+   return abs_path($file) if $^O eq q/darwin/;
 
    while ($Config::Config{d_symlink} and -l $file) {
        if ($file =~ /^(.*?\.\Q$Config{dlext}\E\.\d+)\..*/) {
@@ -1480,34 +1481,6 @@ sub _chase_lib {
 
    return $file;
 }
-
-sub _chase_lib_darwin {
-   my ($self, $file) = @_;
-
-   while (-l $file) {
-       if ($file =~ /^(.*?\.\d+)(\.\d+)*\.dylib$/) {
-           my $name = $1 . q/.dylib/;
-           return $name if -e $name;
-       }
-
-       return $file if $file =~ /\D\.\d+\.dylib$/;
-
-       my $dir = File::Basename::dirname($file);
-       $file = readlink($file);
-
-       unless (File::Spec->file_name_is_absolute($file)) {
-           $file = File::Spec->rel2abs($file, $dir);
-       }
-   }
-
-   if ($file =~ /^(.*?\.\d+)(\.\d+)*\.dylib$/) {
-       my $name = $1 . q/.dylib/;
-       return $name if -e $name;
-   }
-
-   return $file;
-}
-
 
 sub _find_shlib {
     my ($self, $file) = @_;


### PR DESCRIPTION
For example, when providing pp with the option -l /usr/local/opt/glib/lib/libgobject-2.0.0.dylib the _chase_lib_darwin sub will return its name as libgobject-2.0.dylib which then gets packed by pp. However, the application binary looks for libgobject-2.0.0.dylib which it will not be able to find.
 
Cwd::abs_path does the same thing and is in core, so replace _chase_lib_darwin with that.