### PR TITLE
Revert "remove PAR_ARGV_*, PAR_ARGC stuff, not needed"

### DIFF
--- a/myldr/boot.c
+++ b/myldr/boot.c
@@ -124,6 +124,7 @@ int main ( int argc, char **argv, char **env )
     char *my_file;
     char *my_perl;
     char *my_prog;
+    char buf[20];	/* must be large enough to hold "PAR_ARGV_###" */
 #ifdef WIN32
 typedef BOOL (WINAPI *pALLOW)(DWORD);
     HINSTANCE hinstLib;
@@ -199,6 +200,15 @@ typedef BOOL (WINAPI *pALLOW)(DWORD);
             DIE;
         }
         emb_file++;
+    }
+
+    /* save original argv[] into environment variables PAR_ARGV_# */
+    sprintf(buf, "%i", argc);
+    par_setenv("PAR_ARGC", buf);
+    for (i = 0; i < argc; i++) {
+        sprintf(buf, "PAR_ARGV_%i", i);
+        par_unsetenv(buf);
+        par_setenv(buf, argv[i]);
     }
 
     /* finally spawn the custom Perl interpreter */

--- a/myldr/utils.c
+++ b/myldr/utils.c
@@ -239,6 +239,8 @@ void par_init_env () {
     par_unsetenv("PAR_DEBUG");
     par_unsetenv("PAR_CACHE");
     par_unsetenv("PAR_PROGNAME");
+    par_unsetenv("PAR_ARGC");
+    par_unsetenv("PAR_ARGV_0");
 
     if ( (buf = par_getenv("PAR_GLOBAL_DEBUG")) != NULL ) {
         par_setenv("PAR_DEBUG", buf);

--- a/script/par.pl
+++ b/script/par.pl
@@ -210,6 +210,16 @@ BEGIN {
 
 _par_init_env();
 
+if (exists $ENV{PAR_ARGV_0} and $ENV{PAR_ARGV_0} ) {
+    @ARGV = map $ENV{"PAR_ARGV_$_"}, (1 .. $ENV{PAR_ARGC} - 1);
+    $0 = $ENV{PAR_ARGV_0};
+}
+else {
+    for (keys %ENV) {
+        delete $ENV{$_} if /^PAR_ARGV_/;
+    }
+}
+
 my $quiet = !$ENV{PAR_DEBUG};
 
 # fix $progname if invoked from PATH


### PR DESCRIPTION
Removing PAR_ARGV_* and PAR_ARGC breaks command-line parsing on Windows.
Arguments with spaces get split into separate arguments.

This reverts commit 4cd9683fab1cd0839704c4c1708b868b7c76e683.

I haven't dug into PAR/PP internals, but I believe that this is caused by the fact that on Windows programs receive the command as a single string and have to parse out ARGC and ARGV individually.  The bootstrap executable parses them correctly, but then they get stringified improperly when handing off to the packed perl/script executable.

Some references in Windows argument passing:
https://blogs.msdn.microsoft.com/twistylittlepassagesallalike/2011/04/23/everyone-quotes-command-line-arguments-the-wrong-way/
http://blogs.perl.org/users/graham_knop/2011/12/using-system-or-exec-safely-on-windows.html

The bug can be seen with the following script:
```perl
print join(':', @ARGV)
```
Packed with PP 1.36, `a.exe "foo bar"` prints `foo bar`.
Packed with PP 1.37, `a.exe "foo bar"` prints `foo:bar`.