### PR TITLE
Fix Makefile target order for parallel build

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -105,7 +105,7 @@ WriteMakefile1(
 );
 
 # parallel make: install modules into blib *before* recursing into "myldr"
-sub MY::postamble { return "subdirs :: pm_to_blib\n" }
+sub MY::depend { return "subdirs :: pm_to_blib\n" }
 
 sub WriteMakefile1 {  #Compatibility code for old versions of EU::MM. Written by Alexandr Ciornii, version 2. Added by eumm-upgrade.
     my %params=@_;


### PR DESCRIPTION
- Replace MY:postamble() with MY::depend()
(fix:  #7)