### PR TITLE
change unpack dir under windows

### DIFF
--- a/myldr/mktmpdir.c
+++ b/myldr/mktmpdir.c
@@ -78,7 +78,11 @@ char *par_mktmpdir ( char **argv ) {
     const char *temp_dirs[] = { 
         P_tmpdir, 
         ".", NULL };
-    const char *temp_keys[] = { "PAR_TMPDIR", "TMPDIR", "TEMPDIR", 
+    const char *temp_keys[] = { "PAR_TMPDIR",
+#ifdef WIN32
+                                "LOCALAPPDATA",
+#endif
+                                "TMPDIR", "TEMPDIR", 
                                  "TEMP", "TMP", NULL };
     const char *user_keys[] = { "USER", "USERNAME", NULL };
 

--- a/myldr/mktmpdir.c
+++ b/myldr/mktmpdir.c
@@ -135,19 +135,6 @@ char *par_mktmpdir ( char **argv ) {
         }
     }
 
-#ifdef WIN32
-    /* Try the windows temp directory */
-    if ( tmpdir == NULL && (val = par_getenv("WinDir")) && strlen(val) ) {
-        char* buf = malloc(strlen(val) + 5 + 1);
-        sprintf(buf, "%s\\temp", val);
-        if (isWritableDir(buf)) {
-            tmpdir = buf;
-        } else {
-            free(buf);
-        }
-    }
-#endif
-
     /* Try default locations */
     for ( i = 0 ; tmpdir == NULL && (val = temp_dirs[i]) && strlen(val) ; i++ ) {
         if ( isWritableDir(val) ) {

--- a/myldr/mktmpdir.c
+++ b/myldr/mktmpdir.c
@@ -77,9 +77,6 @@ char *par_mktmpdir ( char **argv ) {
     /* NOTE: all arrays below are NULL terminated */
     const char *temp_dirs[] = { 
         P_tmpdir, 
-#ifdef WIN32
-        "C:\\TEMP", 
-#endif
         ".", NULL };
     const char *temp_keys[] = { "PAR_TMPDIR", "TMPDIR", "TEMPDIR", 
                                  "TEMP", "TMP", NULL };

--- a/myldr/mktmpdir.c
+++ b/myldr/mktmpdir.c
@@ -154,14 +154,16 @@ char *par_mktmpdir ( char **argv ) {
         strlen(subdirbuf_suffix) + 1024;
 
     /* stmpdir is what we are going to return; 
-       top_tmpdir is the top $TEMP/par-$USER, needed to build stmpdir.  
+       top_tmpdir is the top $TEMP/par-$USER ($TEMP/pp on Windows),
+       needed to build stmpdir.  
        NOTE: We need 2 buffers because snprintf() can't write to a buffer
        it is also reading from. */
     top_tmpdir = malloc( stmp_len );
-    sprintf(top_tmpdir, "%s%s%s%s", tmpdir, dir_sep, subdirbuf_prefix, username);
 #ifdef WIN32
+    sprintf(top_tmpdir, "%s\\pp", tmpdir);
     _mkdir(top_tmpdir);         /* FIXME bail if error (other than EEXIST) */
 #else
+    sprintf(top_tmpdir, "%s%s%s%s", tmpdir, dir_sep, subdirbuf_prefix, username);
     {
         if (mkdir(top_tmpdir, 0700) == -1 && errno != EEXIST) {
             fprintf(stderr, "%s: creation of private subdirectory %s failed (errno=%i)\n", 

--- a/script/par.pl
+++ b/script/par.pl
@@ -752,7 +752,7 @@ sub _set_par_temp {
 
     foreach my $path (
         (map $ENV{$_}, qw( PAR_TMPDIR TMPDIR TEMPDIR TEMP TMP )),
-        qw( C:\\TEMP /tmp . )
+        qw( /tmp . )
     ) {
         next unless defined $path and -d $path and -w $path;
         my $username;

--- a/script/par.pl
+++ b/script/par.pl
@@ -750,28 +750,37 @@ sub _set_par_temp {
         return;
     }
 
+    #  non-windows should not have LOCALAPPDATA, but just to be sure...
+    my @paths = $^O eq 'MSWin32'
+     ? qw( PAR_TMPDIR LOCALAPPDATA TMPDIR TEMPDIR TEMP TMP )
+     : qw( PAR_TMPDIR TMPDIR TEMPDIR TEMP TMP );
+
     foreach my $path (
-        (map $ENV{$_}, qw( PAR_TMPDIR TMPDIR TEMPDIR TEMP TMP )),
+        (map $ENV{$_}, @paths),
         qw( /tmp . )
     ) {
         next unless defined $path and -d $path and -w $path;
         my $username;
-        my $pwuid;
-        # does not work everywhere:
-        eval {($pwuid) = getpwuid($>) if defined $>;};
 
-        if ( defined(&Win32::LoginName) ) {
-            $username = &Win32::LoginName;
-        }
-        elsif (defined $pwuid) {
-            $username = $pwuid;
+        #  match code in mktempdir.c
+        my $stmpdir;
+        if ( $^O eq 'MSWin32' ) {
+            $stmpdir = "$path$Config{_delim}pp"
         }
         else {
-            $username = $ENV{USERNAME} || $ENV{USER} || 'SYSTEM';
+            my $pwuid;
+            # does not work everywhere:
+            eval {($pwuid) = getpwuid($>) if defined $>;};
+            if (defined $pwuid) {
+                $username = $pwuid;
+            }
+            else {
+                $username = $ENV{USERNAME} || $ENV{USER} || 'SYSTEM';
+            }
+            $username =~ s/\W/_/g;
+            $stmpdir = "$path$Config{_delim}par-".unpack("H*", $username);
         }
-        $username =~ s/\W/_/g;
 
-        my $stmpdir = "$path$Config{_delim}par-".unpack("H*", $username);
         mkdir $stmpdir, 0755;
         if (!$ENV{PAR_CLEAN} and my $mtime = (stat($progname))[9]) {
             open (my $fh, "<". $progname);


### PR DESCRIPTION
This PR changes the default pp unpack directory under Windows to be in the user's %LOCALAPPDATA% directory, following discussions in and around https://rt.cpan.org/Public/Bug/Display.html?id=132811#txn-1902197 


The system could alternately unpack under ```%LOCALAPPDATA%/Programs```.  This seems to be where some other programs are installed locally (Python and MS VS Code in my case) so might be easier to find.

I also wonder if the top directory could include the exe name to make it easier to identify, e.g. for later removal.
