### PR TITLE
FIX: Get exe size from file handle instead of path

### DIFF
--- a/script/par.pl
+++ b/script/par.pl
@@ -240,7 +240,7 @@ MAGIC: {
 
     # Search for the "\nPAR.pm\n signature backward from the end of the file
     my $buf;
-    my $size = -s $progname;
+    my $size = -s _FH;
     my $chunk_size = 64 * 1024;
     my $magic_pos;
 


### PR DESCRIPTION
## Description
Use a file handle instead of a path to determine file size.

## Motivation
Stat and the `-s` operator do not seem to support the `\\?\` prefix that IIS adds when executing CGI. This meant that `par.pl` could never determine the size of the called exe breaking the magic position logic.

## Related Issues
- #41 