### PR TITLE
Adding support for running MacOS Universal binaries

### DIFF
--- a/myldr/boot.c
+++ b/myldr/boot.c
@@ -8,6 +8,14 @@
 #include <stdio.h>
 #include <stdarg.h>
 #endif
+#ifdef __MACH__
+#include <sys/sysctl.h>
+#include <mach-o/fat.h>
+#include <mach-o/loader.h>
+#include <sys/stat.h>
+#include <stdlib.h>
+#include <string.h> 
+#endif
 
 #include "mktmpdir.c"
 
@@ -77,6 +85,58 @@ int extract_embedded_file(embedded_file_t *emb_file, const char* ext_name, const
     return EXTRACT_OK;
 }
 
+/* Simple magic number reader for MacOS */
+#ifdef __MACH__
+uint32_t read_magic(FILE *obj_file, int offset) {
+  uint32_t magic;
+  fseek(obj_file, offset, SEEK_SET);
+  fread(&magic, sizeof(uint32_t), 1, obj_file);
+  return magic;
+}
+
+/* Duplicate argv with some changes */
+char **copy_argv(int argc, char *argv[], char *newpath) {
+  int length=0;
+  size_t ptr_args = argc + 1;
+  // New argv[0]
+  length += strlen(newpath);
+  for (int i = 1; i < argc; i++)
+  {
+    length += (strlen(argv[i]) + 1);
+  }
+  char** new_argv = (char**)malloc((ptr_args) * sizeof(char*) + length);
+  // copy argv into the contiguous buffer
+  // first the new argv[0]
+  new_argv[0] = &(((char*)new_argv)[(ptr_args * sizeof(char*))]);
+  strcpy(new_argv[0], newpath);
+
+  length = strlen(newpath);
+  for (int i = 1; i < argc; i++)
+  {
+    new_argv[i] = &(((char*)new_argv)[(ptr_args * sizeof(char*)) + length]);
+    strcpy(new_argv[i], argv[i]);
+    length += (strlen(argv[i]) + 1);
+  }
+  // insert NULL terminating ptr at the end of the ptr array
+  new_argv[ptr_args-1] = NULL;
+  return (new_argv);
+}
+
+/* double slashes in the tmpdir path confuse execve */
+char *sanitise_tmp(char *s) {
+  if (s) {
+    const char *src = s;
+    char *dst = s;
+    while ((*dst = *src) != '\0') {
+      do {
+        src++;
+      } while ((*dst == '/' || *dst == '\\')  && (*src == '/' || *src == '\\'));
+      dst++;
+    }
+  }  
+  return s;
+}
+#endif
 
 /* turn off automatic globbing of process arguments when using MingW */
 #if defined(WIN32) && defined(__MINGW32__)
@@ -192,7 +252,7 @@ typedef BOOL (WINAPI *pALLOW)(DWORD);
 
     par_init_env();
 
-    stmpdir = par_mktmpdir( argv );	
+    stmpdir = par_mktmpdir( argv );
     if ( !stmpdir ) die("");        /* error message has already been printed */
 
     rc = my_mkdir(stmpdir, 0700);
@@ -204,6 +264,66 @@ typedef BOOL (WINAPI *pALLOW)(DWORD);
     /* extract embedded_files[0] (i.e. the custom Perl interpreter) 
      * into stmpdir (but under the same basename as argv[0]) */
     my_prog = par_findprog(argv[0], par_getenv("PATH"));
+
+#ifdef __MACH__
+    /* Detect if FAT binary */
+    FILE *obj_file = fopen(my_prog, "rb");
+    uint32_t magic = read_magic(obj_file, 0);
+    fclose(obj_file);
+    if (magic == FAT_CIGAM || magic == FAT_MAGIC) {
+
+      /* Create seperate dir for extracted thin binary*/
+      char *ftmpdir = malloc(strlen(stmpdir)+4);
+      ftmpdir = par_mktmpdir( argv );
+      strcat(ftmpdir, "_FAT");
+      sanitise_tmp(ftmpdir);
+      rc = my_mkdir(ftmpdir, 0700);
+      if ( rc == -1 && errno != EEXIST) {
+	die("%s: creation of MacOS extracted thin binary private cache subdirectory %s failed (errno= %i)\n", 
+            argv[0], ftmpdir, errno);
+      }
+      
+      /* Get architecture name */
+      size_t size;
+      sysctlbyname("hw.machine", NULL, &size, NULL, 0);
+      char *arch = malloc(size);
+      sysctlbyname("hw.machine", arch, &size, NULL, 0);
+
+      /* Detect if lipo exists, if not die */
+      struct stat buffer;
+      int exist = stat("/usr/bin/lipo", &buffer);
+      if(exist == 0) {
+        char *archthinbin = malloc(strlen(ftmpdir)+strlen(arch)+11);
+        strcat(archthinbin, ftmpdir);
+        strcat(archthinbin, "/biberthin_");
+        strcat(archthinbin, arch);
+        char *lipocmd = malloc(strlen(arch)+strlen(archthinbin)+strlen(my_prog)+40);
+        strcat(lipocmd, "/usr/bin/lipo -extract_family ");
+        strcat(lipocmd, arch);
+        strcat(lipocmd, " -output ");
+        strcat(lipocmd, archthinbin);
+        strcat(lipocmd, " ");
+        strcat(lipocmd, my_prog);
+        system(lipocmd);
+        free(arch);
+
+        /* exec correct thin binary */
+        exist = stat(archthinbin, &buffer);
+        if(exist == 0) {
+          char **nargv = copy_argv(argc, argv, archthinbin);
+          execve(archthinbin, nargv, env);
+          die("%s: Cannot execute thin binary %s (errno=%i)\n", argv[0], archthinbin, errno);
+        }
+        else {
+          die("%s: Cannot find thin binary %s to run (errno=%i)\n", argv[0], archthinbin, errno);
+        }
+      }
+      else {
+	die("%s: Cannot find /usr/bin/lipo to unpack universal binary - do you need install Developer Tools? (errno=%i)\n", argv[0], errno);
+      }
+    }
+#endif    
+    
     rc = extract_embedded_file(embedded_files, par_basename(my_prog), stmpdir, &my_perl);
     if (rc == EXTRACT_FAIL) {
         die("%s: extraction of %s (custom Perl interpreter) failed (errno=%i)\n", 


### PR DESCRIPTION
This patch only alters the `boot.c` code for MacOS. It:

- Checks to see if the exe is a universal binary
- If it isn't, proceed as normal
- If it is, extract the local arch version of the binary to a thin, non-universal binary in a dedicated cache dir with "_FAT" postfix
- exevce over the existing process to run the thin arch-specific binary

I had to post-process the tmpdir used as `par_mktmpdir` results in paths with repeated slashes in it which `execve` doesn't like.

One thing to check is whether generic MacOS contains `/usr/binb/lipo` without having Developer Tools installed. The code checks for this anyway.

Tested with a Universal ARM64/x86_64 binary which, using this patch, runs on both now - before, it only runs the last binary in the FAT binary, the other(s) erroring out, as expected.